### PR TITLE
Correct TEXT_ALIGN_RIGHT alignment calculation

### DIFF
--- a/LedMatrix.cpp
+++ b/LedMatrix.cpp
@@ -80,7 +80,7 @@ void LedMatrix::calculateTextAlignmentOffset() {
             myTextAlignmentOffset = myNumberOfDevices * 8;
             break;
         case TEXT_ALIGN_RIGHT:
-            myTextAlignmentOffset = myText.length() * myCharWidth - myNumberOfDevices * 8;
+            myTextAlignmentOffset = myNumberOfDevices * 8 - myText.length() * myCharWidth;
             break;
         case TEXT_ALIGN_RIGHT_END:
             myTextAlignmentOffset = - myText.length() * myCharWidth;


### PR DESCRIPTION
Changed order of operands. Tested only with just one matrix unit (myNumberOfDevices = 1).
