### PR TITLE
Added function to rotate each 8x8 matrix 90° left

### DIFF
--- a/LedMatrix.cpp
+++ b/LedMatrix.cpp
@@ -93,12 +93,14 @@ void LedMatrix::calculateTextAlignmentOffset() {
 void LedMatrix::clear() {
     for (byte col = 0; col < myNumberOfDevices * 8; col++) {
         cols[col] = 0;
-		rotatedCols[col] = 0;
+		//rotatedCols[col] = 0;
     }    
 }
 
 void LedMatrix::commit() {
-	rotateLeft();
+	if ( rotationIsEnabled ) {
+		rotateLeft();
+	}
     for (byte col = 0; col < myNumberOfDevices * 8; col++) {
         sendByte(col / 8, col % 8 + 1, cols[col]);
     }
@@ -165,6 +167,10 @@ void LedMatrix::setColumn(int column, byte value) {
 
 void LedMatrix::setPixel(byte x, byte y) {
     bitWrite(cols[x], y, true);
+}
+
+void LedMatrix::setRotation(bool enabled) {
+	rotationIsEnabled = enabled;
 }
 
 void LedMatrix::rotateLeft() {	

--- a/LedMatrix.cpp
+++ b/LedMatrix.cpp
@@ -9,6 +9,7 @@ LedMatrix::LedMatrix(byte numberOfDevices, byte slaveSelectPin) {
     myNumberOfDevices = numberOfDevices;
     mySlaveSelectPin = slaveSelectPin;
     cols = new byte[numberOfDevices * 8];
+	rotatedCols = new byte[numberOfDevices * 8];
 }
 
 /**
@@ -92,11 +93,12 @@ void LedMatrix::calculateTextAlignmentOffset() {
 void LedMatrix::clear() {
     for (byte col = 0; col < myNumberOfDevices * 8; col++) {
         cols[col] = 0;
-    }
-    
+		rotatedCols[col] = 0;
+    }    
 }
 
 void LedMatrix::commit() {
+	rotateLeft();
     for (byte col = 0; col < myNumberOfDevices * 8; col++) {
         sendByte(col / 8, col % 8 + 1, cols[col]);
     }
@@ -163,4 +165,15 @@ void LedMatrix::setColumn(int column, byte value) {
 
 void LedMatrix::setPixel(byte x, byte y) {
     bitWrite(cols[x], y, true);
+}
+
+void LedMatrix::rotateLeft() {	
+	for (byte deviceNum = 0; deviceNum < myNumberOfDevices; deviceNum++) {		
+		for(byte posY = 0; posY < 8; posY++) {
+			for(byte posX = 0; posX < 8; posX++) {
+				bitWrite(rotatedCols[8 * (deviceNum) + posY], posX, bitRead(cols[8 * (deviceNum) + 7-posX], posY));						
+			}
+		}
+	}
+	memcpy(cols, rotatedCols, myNumberOfDevices * 8);
 }

--- a/LedMatrix.cpp
+++ b/LedMatrix.cpp
@@ -93,7 +93,6 @@ void LedMatrix::calculateTextAlignmentOffset() {
 void LedMatrix::clear() {
     for (byte col = 0; col < myNumberOfDevices * 8; col++) {
         cols[col] = 0;
-		//rotatedCols[col] = 0;
     }    
 }
 

--- a/LedMatrix.h
+++ b/LedMatrix.h
@@ -119,6 +119,7 @@ public:
     
 private:
     byte* cols;
+	byte* rotatedCols;
     byte spiregister[8];
     byte spidata[8];
     String myText;
@@ -132,4 +133,5 @@ private:
     byte myTextAlignment = 1;
     
     void calculateTextAlignmentOffset();
+	void rotateLeft();
 };

--- a/LedMatrix.h
+++ b/LedMatrix.h
@@ -116,6 +116,11 @@ public:
      * Oscilate the text between the two limits.
      */
     void oscillateText();
+	
+	/**
+     * Enables 90° rotation for each 8x8 matrix.
+     */
+	void setRotation(bool enabled);
     
 private:
     byte* cols;
@@ -131,6 +136,7 @@ private:
     byte mySlaveSelectPin = 0;
     byte myCharWidth = 7;
     byte myTextAlignment = 1;
+	bool rotationIsEnabled = false;
     
     void calculateTextAlignmentOffset();
 	void rotateLeft();


### PR DESCRIPTION
This one resolves #7 with a new function LedMatrix::setRotation(true|false). The rotation in rotateLeft is done with simple bitwise copying and may be optimized.
